### PR TITLE
Update `Charls` to version `2.3.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ about:
   license_family: BSD
   license_file: LICENSE.md
   summary: CharLS is a C++ implementation of the JPEG-LS standard for lossless and near-lossless image compression and decompression. JPEG-LS is a low-complexity image compression standard that matches JPEG 2000 compression ratios.
+  dev_url: https://github.com/team-charls/charls
+  doc_url: https://github.com/team-charls/charls/tree/master/doc 
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.0" %}
+{% set version = "2.3.2" %}
 
 package:
   name: charls
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/team-charls/charls/archive/{{ version }}.tar.gz
-  sha256: e1d7dd70cd9d6d46de5abbf22278dc8169707995a21e8bf705f5746c04c76891
+  sha256: b758e3f3a6f875d69454f6131fe7a4daf574f8b0e2c890dc9f8c1d3083a4dc78
 
 build:
   skip: true  # [win and vc<14]


### PR DESCRIPTION
  `charls` version `2.3.2`
1. - [x] check the upstream

    https://github.com/team-charls/charls/tree/2.3.2
  
2. - [x] check the pinnings
    
https://github.com/team-charls/charls/blob/master/CMakeLists.txt

https://github.com/team-charls/charls/blob/master/src/charls_jpegls_encoder.cpp

https://github.com/team-charls/charls/blob/master/src/encoder_strategy.h

3. - [x] check the changelogs
    
    https://github.com/team-charls/charls/blob/2.3.2/CHANGELOG.md

    Now `C++14` is the minimum supported version
    Updates to the `CMakeLists.txt` for `Unix builds` (except macOS) to hide more symbols from the shared library.

    the rest of the changes were bug fixes
  
4. - [x] additional research

    https://github.com/conda-forge/charls-feedstock/issues

    there are no open issues currently mentioned in `conda-forge`

5. - [x] verify dev_url

    https://github.com/team-charls/charls
  
6. - [x] verify doc_url
  
    https://github.com/team-charls/charls/tree/master/doc
  
7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
10. - [x] verify setuptools
     
     `setuptools` is not a dependency for this packages

11. - [x] verify wheel

     `wheel` is not a dependency for this packages

12. - [x] pip in the test section

     `pip` is not a dependency for this packages

13. - [x] veriy the test section

Results:
-  All checks have passed


Based on the research findings and the results we can conclude
that it is safe to update `charls` to version `2.3.2`
